### PR TITLE
Update documentation link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This plugin aims to provide data persistence capabilities to Lyra.
 
 # Usage
 
-For the complete usage guide, please refer to the [official plugin documentation](https://docs.lyrajs.io/docs/plugins/plugin-data-persistence).
+For the complete usage guide, please refer to the [official plugin documentation](https://docs.lyrajs.io/plugins/plugin-data-persistence).
 
 # License
 


### PR DESCRIPTION
This PR updates the official documentation link on the README.

As reported on #5 is necessary to update the `website` voice into the **repository details** by removing the `docs` prefix.