### PR TITLE
Restore defaultLanguage from file

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -77,6 +77,7 @@ export function restore<T extends PropertiesSchema> (format: PersistenceFormat =
   }
 
   db.index = deserialized.index
+  db.defaultLanguage = deserialized.defaultLanguage
   db.docs = deserialized.docs
   db.nodes = deserialized.nodes
   db.schema = deserialized.schema


### PR DESCRIPTION
DefaultLanguage is not properly restored. As such, when you set the indexer to Arabic and save to disk, searches won't work on restore. Unless you go out of your way and manually change the defaultLanguage prop of the restoredInstance to Arabic. This change is dependent on having the lyra save also change (I will open another pull request for that):
```

export function save<S extends PropertiesSchema>(lyra: Lyra<S>): Data<S> {
  return {
    index: lyra.index,
    defaultLanguage: lyra.defaultLanguage, <--- this needs to be added.
    docs: lyra.docs,
    nodes: lyra.nodes,
    schema: lyra.schema,
    frequencies: lyra.frequencies,
    tokenOccurrencies: lyra.tokenOccurrencies,
  };
}
```